### PR TITLE
Fix security vulnerability(CVE-2019-13574)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'carrierwave'
 
 # https://github.com/minimagick/minimagick
 # Mini replacement for RMagick
-gem 'mini_magick'
+gem 'mini_magick', '>= 4.9.4'
 
 # https://github.com/plataformatec/devise
 # Flexible authentication solution for Rails with Warden.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mini_magick (4.9.2)
+    mini_magick (4.9.5)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -299,7 +299,7 @@ DEPENDENCIES
   fast_jsonapi
   kaminari
   listen (>= 3.0.5, < 3.2)
-  mini_magick
+  mini_magick (>= 4.9.4)
   oj
   pg
   pry-rails


### PR DESCRIPTION
In lib/mini_magick/image.rb in MiniMagick before 4.9.4, a fetched remote image filename could cause remote command execution because
Image.open input is directly passed to Kernel#open, which accepts a '|' character followed by a command.