### PR TITLE
Fix CVE-2019-16109

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'mini_magick', '>= 4.9.4'
 
 # https://github.com/plataformatec/devise
 # Flexible authentication solution for Rails with Warden.
-gem 'devise', '>= 4.6.1'
+gem 'devise', '>= 4.7.1'
 
 # OAuth 2 provider for Ruby on Rails / Grape.
 # https://github.com/doorkeeper-gem/doorkeeper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     arel (8.0.0)
     ast (2.4.0)
     batch-loader (1.2.2)
-    bcrypt (3.1.12)
+    bcrypt (3.1.13)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
@@ -70,10 +70,10 @@ GEM
     crass (1.0.4)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
-    devise (4.6.1)
+    devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 6.0)
+      railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
@@ -202,9 +202,9 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.6.0)
       redis (>= 2.2, < 5)
-    responders (2.4.1)
-      actionpack (>= 4.2.0, < 6.0)
-      railties (>= 4.2.0, < 6.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -292,7 +292,7 @@ DEPENDENCIES
   carrierwave
   connection_pool
   database_cleaner
-  devise (>= 4.6.1)
+  devise (>= 4.7.1)
   doorkeeper (>= 5.0.1)
   factory_bot_rails
   faker
@@ -323,4 +323,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.1
+   1.17.2


### PR DESCRIPTION
An issue was discovered in Plataformatec Devise before 4.7.1.
It confirms accounts upon receiving a request with a blank confirmation_token,
if a database record has a blank value in the confirmation_token column.
(However, there is no scenario within Devise itself in which such database records would exist.)