### PR TITLE
Fix CVE-2019-18978

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'rack-attack'
 
 # Rack Middleware for handling Cross-Origin Resource Sharing (CORS), which makes cross-origin AJAX possible.
 # https://github.com/cyu/rack-cors
-gem 'rack-cors', require: 'rack/cors'
+gem 'rack-cors', '>= 1.0.6', require: 'rack/cors'
 
 # Cache
 gem 'connection_pool'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,8 @@ GEM
     rack (2.0.7)
     rack-attack (5.4.2)
       rack (>= 1.0, < 3)
-    rack-cors (1.0.2)
+    rack-cors (1.0.6)
+      rack (>= 1.6.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.7)
@@ -305,7 +306,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.7)
   rack-attack
-  rack-cors
+  rack-cors (>= 1.0.6)
   rails (~> 5.1.7)
   redis
   redis-namespace


### PR DESCRIPTION
An issue was discovered in the rack-cors (aka Rack CORS Middleware) gem before 1.0.4 for Ruby.
It allows ../ directory traversal to access private resources because resource matching does not ensure that pathnames are in a canonical format.