### PR TITLE
Fix vulnerability CVE-2020-7595

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     nio4r (2.4.0)
-    nokogiri (1.10.5)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     oj (3.7.0)
     orm_adapter (0.5.0)


### PR DESCRIPTION
xmlStringLenDecodeEntities in parser.c in libxml2 2.9.10 has an infinite loop in a certain end-of-file situation.
The Nokogiri RubyGem has patched it's vendored copy of libxml2 in order to prevent this issue from affecting nokogiri.