### PR TITLE
Fix GHSA-33vf-4xgg-9r58, GHSA-84j7-475p-hp8v

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'settingslogic'
 
 # A Ruby/Rack web server built for concurrency
 # https://github.com/puma/puma
-gem 'puma', '>= 3.12.2'
+gem 'puma', '>= 4.3.3'
 
 # A Ruby interface to the PostgreSQL RDBMS.
 # https://github.com/ged/ruby-pg

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     pry-rails (0.3.8)
       pry (>= 0.10.4)
     public_suffix (3.0.3)
-    puma (4.3.1)
+    puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.0.8)
     rack-attack (5.4.2)
@@ -305,7 +305,7 @@ DEPENDENCIES
   oj
   pg
   pry-rails
-  puma (>= 3.12.2)
+  puma (>= 4.3.3)
   rack-attack
   rack-cors (>= 1.0.6)
   rails (~> 5.1.7)


### PR DESCRIPTION
GHSA-33vf-4xgg-9r58

If an application using Puma allows untrusted input in an early-hints header, an attacker can use a carriage return character to end the header and inject malicious content, such as additional headers or an entirely new response body. This vulnerability is known as HTTP Response Splitting

While not an attack in itself, response splitting is a vector for several other attacks, such as cross-site scripting (XSS).

This is related to CVE-2020-5247, which fixed this vulnerability but only for regular responses.

GHSA-84j7-475p-hp8v

In Puma (RubyGem) before 4.3.2 and 3.12.3, if an application using Puma allows untrusted input in a response header,
an attacker can use newline characters (i.e. CR, LF or/r, /n) to end the header and inject malicious content,
such as additional headers or an entirely new response body. This vulnerability is known as HTTP Response Splitting.

While not an attack in itself, response splitting is a vector for several other attacks, such as cross-site scripting (XSS).

This is related to CVE-2019-16254, which fixed this vulnerability for the WEBrick Ruby web server.

This has been fixed in versions 4.3.2 and 3.12.3 by checking all headers for line endings and rejecting headers with those characters.