### PR TITLE
Fix security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'devise'
 
 # OAuth 2 provider for Ruby on Rails / Grape.
 # https://github.com/doorkeeper-gem/doorkeeper
-gem 'doorkeeper'
+gem 'doorkeeper', '~> 5.3.2'
 
 # A Ruby implementation of GraphQL.
 # https://github.com/rmosolgo/graphql-ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,8 +75,8 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.1)
-    doorkeeper (5.0.2)
-      railties (>= 4.2)
+    doorkeeper (5.3.3)
+      railties (>= 5)
     equalizer (0.0.11)
     erubi (1.9.0)
     factory_bot (4.11.1)
@@ -270,7 +270,7 @@ DEPENDENCIES
   connection_pool
   database_cleaner
   devise
-  doorkeeper
+  doorkeeper (~> 5.3.2)
   factory_bot_rails
   faker
   graphiql-rails


### PR DESCRIPTION
GHSA-j7vx-8mqj-cqp9

Information disclosure vulnerability. Allows an attacker to see all Doorkeeper::Application model attribute values (including secrets) using authorized applications controller if it's enabled (GET /oauth/authorized_applications.json).